### PR TITLE
Added resource_type management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,18 @@ export default buildConfig({
     ....
 })
 ```
+
+### mediaManagement function
+
+```js
+function mediaManagement(
+  config?: ConfigOptions,
+  uploadApiOptions?: UploadApiOptions,
+  uploadResourceTypeHandler?: Function
+)
+```
+
+The function may receive a `ConfigOptions` and a `UploadApiOptions` from `cloudinary` package.
+Additionally, you can specify a `uploadResourceTypeHandler` to manage which `resource_type` parameter must be passed to `cloudinary.upload` (see here: https://cloudinary.com/documentation/image_upload_api_reference#upload_optional_parameters for additional information).
+
+If the `uploadResourceTypeHandler` is NOT specified, `resource_type: auto` will be passed to upload method.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-cloudinary-plugin",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/finkinfridom/payload-cloudinary-plugin.git",


### PR DESCRIPTION
As per issue #10 , the `resource_type` optional parameter will allow upload of different files than images.

Now, by default the value will be `auto` or you can define a dedicated `uploadResourceTypeHandler` function to pick your best choice