### PR TITLE
Fixed `delete` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-cloudinary-plugin",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/finkinfridom/payload-cloudinary-plugin.git",

--- a/src/plugins/cloudinaryPlugin.ts
+++ b/src/plugins/cloudinaryPlugin.ts
@@ -14,9 +14,11 @@ import { CloudinaryPluginRequest, PluginConfig } from "../types";
 
 export const GROUP_NAME = "cloudinary";
 export const DEFAULT_REQUIRED_FIELDS = [
-  { name: "public_id", label: "Public ID" },
+  { name: "public_id", label: "Public ID", required: true },
   { name: "original_filename", label: "Original filename" },
+  { name: "format", label: "Format" },
   { name: "secure_url", label: "URL" },
+  { name: "resource_type", label: "Resource Type", required: true },
 ];
 
 const setCloudinaryField = (inputField: Partial<Field> | string): Field => {
@@ -80,6 +82,7 @@ export const beforeChangeHook: CollectionBeforeChangeHook = async (args) => {
     throw new APIError(`Cloudinary: ${JSON.stringify(e)}`);
   }
 };
+
 export const afterDeleteHook: CollectionAfterDeleteHook = async ({
   req,
   doc,
@@ -88,8 +91,12 @@ export const afterDeleteHook: CollectionAfterDeleteHook = async ({
     return;
   }
   try {
+    const apiResponse = doc[GROUP_NAME] as UploadApiResponse;
     await (req as CloudinaryPluginRequest).cloudinaryService.delete(
-      (doc[GROUP_NAME] as UploadApiResponse).public_id
+      apiResponse.public_id,
+      {
+        resource_type: apiResponse.resource_type,
+      }
     );
   } catch (e) {
     throw new APIError(`Cloudinary: ${JSON.stringify(e)}`);


### PR DESCRIPTION
Cloudinary's `destroy` method needs the `resource_type` option to be specified (as it is part of the resource's URL), here as a reference: https://cloudinary.com/documentation/image_upload_api_reference#destroy

Added the` resource_type` field (as required) in the collection's definition and used it into the `delete` method

closes #13 