### PR TITLE
add cloudinary env var info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Extends `payloadcms` with Cloudinary integration
 
 ## Get Started
 
+### Set cloudinary environment variables
+```
+CLOUDINARY_CLOUD_NAME=<your cloud name>
+CLOUDINARY_API_KEY=<your api key>
+CLOUDINARY_API_SECRET=<your api secret>
+```
+
 ### server.ts
 
 ```js


### PR DESCRIPTION
The plugin doesn't work unless the cloudinary api environment variables are configured so it would probably be good to include those in the readme.